### PR TITLE
CORE-8421 Move kameleon.notification-entities to notification-agent.db.entities

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
       (string/trim (:out (sh "git" "rev-parse" "HEAD")))
       ""))
 
-(defproject org.cyverse/notification-agent "2.8.1-SNAPSHOT"
+(defproject org.cyverse/notification-agent "2.10.0-SNAPSHOT"
   :description "A web service for storing and forwarding notifications."
   :url "https://github.com/cyverse-de/notification-agent"
   :license {:name "BSD"

--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,6 @@
                                [com.fasterxml.jackson.core/jackson-core]]]
                  [compojure "1.5.0"]
                  [org.cyverse/clojure-commons "2.8.0"]
-                 [org.cyverse/kameleon "2.8.0"]
                  [org.cyverse/common-cli "2.8.0"]
                  [org.cyverse/service-logging "2.8.0"]
                  [org.cyverse/event-messages "0.0.1"]

--- a/src/notification_agent/db.clj
+++ b/src/notification_agent/db.clj
@@ -1,9 +1,9 @@
 (ns notification-agent.db
   (:use [korma.db]
         [korma.core]
-        [kameleon.notification-entities]
         [notification-agent.config]
         [notification-agent.common]
+        [notification-agent.db.entities]
         [slingshot.slingshot :only [throw+ try+]])
   (:require [clojure.string :as string]
             [notification-agent.time :as time])

--- a/src/notification_agent/db/entities.clj
+++ b/src/notification_agent/db/entities.clj
@@ -1,0 +1,41 @@
+(ns notification-agent.db.entities
+  (:use [korma.core]))
+
+(declare analysis_execution_statuses
+         email_notification_messages
+         notifications
+         system_notification_acknowledgments
+         system_notification_types
+         system_notifications
+         users)
+
+;; Information about users who have received notifications.
+(defentity users
+           (has-many notifications {:fk :user_id})
+           (has-many system_notification_acknowledgments {:fk :user_id}))
+
+;; The notifications themselves.
+(defentity notifications
+           (belongs-to users {:fk :user_id})
+           (has-many email_notification_messages {:fk :notification_id}))
+
+;; The most recent status seen by the notification agent for every job that it's seen.
+(defentity analysis_execution_statuses)
+
+;; Records of email messages sent in response to notifications.
+(defentity email_notification_messages
+           (belongs-to notifications {:fk :notification_id}))
+
+;; Types of system notifications.
+(defentity system_notification_types
+           (has-many system_notifications {:fk :system_notification_type_id}))
+
+;; System notifications.
+(defentity system_notifications
+           (belongs-to system_notification_types {:fk :system_notification_type_id})
+           (has-many system_notification_acknowledgments {:fk :system_notification_id}))
+
+;; Acknowledgments of system notifications.
+(defentity system_notification_acknowledgments
+           (belongs-to users {:fk :user_id})
+           (belongs-to system_notifications {:fk :system_notification_id}))


### PR DESCRIPTION
This PR removes notification-agent's dependency on kameleon by moving `kameleon.notification-entities` to `notification-agent.db.entities`, as part of the cyverse-de/kameleon#6 effort.